### PR TITLE
Unescape HTML elements for question and answer body

### DIFF
--- a/controllers/storeAnswer.js
+++ b/controllers/storeAnswer.js
@@ -21,13 +21,11 @@ module.exports = async (req, res) => {
     // Update the Question Database
     console.log("Body: " + req.body.body);
     console.log("Updating the Question Database : " + req.body.thisQuestionID)
-    let bodyPlainText = req.body.body.replace(/<\/?[^>]+(>|$)/g, "");
-    bodyPlainText = bodyPlainText.replace(/&(nbsp|amp|quot|lt|gt);/g," ");
-    // bodyPlainText = req.body.body; // This is when we fix formatting issue!
+
     const thisQuestion = await Question.findById({_id: req.body.thisQuestionID});
     let currentDate = new Date();
-    console.log("after current date")
-    await Question.updateOne({_id: req.body.thisQuestionID}, {"$push": {"answers" : {respondent: thisUser.username, respondentID:loggedIn, text: bodyPlainText, upvotes:0, date: currentDate}}});
+    console.log("after current date")   
+    await Question.updateOne({_id: req.body.thisQuestionID}, {"$push": {"answers" : {respondent: thisUser.username, respondentID:loggedIn, text: req.body.body, upvotes:0, date: currentDate}}});
 
     // Notify the Individual Who Posted the Question
     try {

--- a/controllers/storePost.js
+++ b/controllers/storePost.js
@@ -13,9 +13,7 @@ module.exports = async (req, res) => {
     await Users.updateOne({ username : thisUser.username}, {$set : {asked : newAsked, rank : newRank}})
 
     // Update the Question Database
-    let bodyPlainText = req.body.body.replace(/<\/?[^>]+(>|$)/g, "");
-    bodyPlainText = bodyPlainText.replace(/&(nbsp|amp|quot|lt|gt);/g," ");
-    Question.create({title: req.body.title, keyword1: req.body.keyword1, body: bodyPlainText, userid: req.session.userId, answers:[]}, (error, user) =>{
+    Question.create({title: req.body.title, keyword1: req.body.keyword1, body: req.body.body, userid: req.session.userId, answers:[]}, (error, user) =>{
       console.log("Inside Question.create")
       if(error){
         console.log(error)

--- a/views/displayAnswers.ejs
+++ b/views/displayAnswers.ejs
@@ -57,7 +57,7 @@
               <div class="carousel-item" style="text-align: justify" >
                 <div class="row" id = "message-body">
                   <h2>Answer:</h2>
-                  <p id="answer_text"><%= answers[i].text %></p>
+                  <p id="answer_text"><%- answers[i].text %></p>
                 </div>
                 <div class="row" id="parent-node">
                   <p><strong>Posted by: </strong><%= answers[i].respondent %> on <%= answers[i].date.toDateString() %> </p>

--- a/views/displayPosts.ejs
+++ b/views/displayPosts.ejs
@@ -55,7 +55,7 @@
               <div class="carousel-item" style="text-align: justify" >
                 <div class="row" id = "message-body">
                   <h2><%= questions[i].title %></h2>
-                  <p><%= questions[i].body %></p>
+                  <p><%- questions[i].body %></p>
                 </div>
                 <div class="row" id="parent-node">
                   <p><strong>Posted by: </strong><%= questions[i].userid.username %> on <%= questions[i].datePosted.toDateString() %> </p>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,8 +42,9 @@
                             <%= questions[i].title %>
                         </h2>
                         <p class="post-subtitle">
-                        <%= questions[i].body.replace('\"', "") %>
+                        <%- questions[i].body.replace('\"', "") %>
                         </p>
+
                         <p class="post-meta">
                             Posted by:
                             <a><%= questions[i].userid.username %></a>


### PR DESCRIPTION
## Describe your changes
This change unescapes HTML elements in the body text of questions and answers by using the `%-` tag instead of the `%=` tag. (See the full EJS documentation [here](https://ejs.co/#docs)). This commit also removes the regexes that replaced HTML with empty space.
