### PR TITLE
Don't submit downvote when user cancels rationale

### DIFF
--- a/views/displayAnswers.ejs
+++ b/views/displayAnswers.ejs
@@ -224,7 +224,6 @@
   
       /* Handle Downvote*/
       $("#minus").click(function(){
-        var rationale = explainDownvote();
         console.log("Inside Minus");
 
         // Find the questionID for the active carousel item
@@ -241,6 +240,9 @@
           // user is changing their vote to -1
 
           var rationale = explainDownvote();
+          if (rationale == null) {
+            return;
+          }
           $.ajax({
             type: "post",
             url: "/vote",

--- a/views/displayPosts.ejs
+++ b/views/displayPosts.ejs
@@ -233,6 +233,9 @@
           
           // Obtain downvote rationale from user
           var rationale = explainDownvote();
+          if (rationale == null) {
+            return;
+          }
           $.ajax({
             type: "post",
             url: "/vote",


### PR DESCRIPTION
Currently, downvoting goes through regardless of whether or not user cancels "rationale". This bugfix stops the app from sending the downvote request in that case.