### PR TITLE
Allow self-signed certificates in sendEmail

### DIFF
--- a/weeklyEmail.js
+++ b/weeklyEmail.js
@@ -50,7 +50,8 @@ async function sendEmail(address, subject, body) {
         auth: {
             user: 'admin@thetaxgaap.com',
             pass: EMAIL_PASSWORD
-        }
+        },
+        tls: { rejectUnauthorized: false }
     });
     return await _sendEmail(address, subject, body, transporter);
 }


### PR DESCRIPTION
GoDaddy uses their own smtp proxy, which has a self-signed SSL certificate. NodeMailer needs a check disabled in order to support this.

We missed this during QA, because testing from laptop hits the public O365 SMTP endpoint. This change supports both cases.